### PR TITLE
Reload after adding items, unlock api/items route

### DIFF
--- a/client/src/pages/Items/Items.js
+++ b/client/src/pages/Items/Items.js
@@ -71,7 +71,7 @@ class Items extends Component {
         price: this.state.price,
         description: this.state.description
       })
-        .then(res => this.loadBooks())
+        .then(res => this.loadItems())
         .catch(err => console.log(err));
     }
   };

--- a/routes/api/item.js
+++ b/routes/api/item.js
@@ -7,16 +7,17 @@ require('../../config/passport')(passport);
 const itemsController = require("../../controllers/itemsController");
 
 /* GET ALL ITEMS */
-router.get('/', passport.authenticate('jwt', { session: false}), function(req, res) {
-  var token = getToken(req.headers);
-  if (token) {
+router.get('/', function(req, res) {
+  // router.get('/', passport.authenticate('jwt', { session: false}), function(req, res) {
+  // var token = getToken(req.headers);
+  // if (token) {
     Item.find(function (err, items) {
       if (err) return next(err);
       res.json(items);
     });
-  } else {
-    return res.status(403).send({success: false, msg: 'Unauthorized.'});
-  }
+  // } else {
+    // return res.status(403).send({success: false, msg: 'Unauthorized.'});
+  // }
 });
 
 router.post('/', passport.authenticate('jwt', { session: false}), function(req, res) {


### PR DESCRIPTION
Fixed the code so that when admin adds an item to inventory, it automatically refreshes the page.  Also removed passport encryption for /api/items route, so now you can view all items at localhost:3001/api/items